### PR TITLE
Remove ngDoCheck

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@blackbaud/skyux": "2.38.0",
-    "@blackbaud/skyux-builder": "1.30.0",
-    "@skyux-sdk/builder-plugin-skyux": "1.0.0-rc.5"
+    "@blackbaud/skyux": "2.40.0",
+    "@blackbaud/skyux-builder": "1.31.1",
+    "@skyux-sdk/builder-plugin-skyux": "1.0.0-rc.6"
   }
 }

--- a/src/app/public/modules/tabs/tab-button.component.ts
+++ b/src/app/public/modules/tabs/tab-button.component.ts
@@ -2,8 +2,13 @@ import {
   Component,
   EventEmitter,
   Input,
-  Output
+  Output,
+  ChangeDetectorRef
 } from '@angular/core';
+
+import {
+  SkyTabsetAdapterService
+} from './tabset-adapter.service';
 
 @Component({
   selector: 'sky-tab-button',
@@ -11,29 +16,65 @@ import {
   styleUrls: ['./tab-button.component.scss']
 })
 export class SkyTabButtonComponent {
-  @Input()
-  public tabHeading: string;
-
-  @Input()
-  public tabHeaderCount: number;
-
-  @Input()
-  public tabStyle: string;
 
   @Input()
   public active: boolean;
 
   @Input()
-  public allowClose: boolean;
+  public disabled: boolean;
 
   @Input()
-  public disabled: boolean;
+  public tabStyle: string;
+
+  @Input()
+  public set allowClose(closeAllowed: boolean) {
+    this._allowClose = closeAllowed;
+    this.ref.detectChanges();
+    this.adapterService.detectOverflow();
+  }
+
+  public get allowClose() {
+    return this._allowClose;
+  }
+
+  @Input()
+  public set tabHeading(heading: string) {
+    this._tabHeading = heading;
+    this.ref.detectChanges();
+    this.adapterService.detectOverflow();
+  }
+
+  public get tabHeading() {
+    return this._tabHeading;
+  }
+
+  @Input()
+  public set tabHeaderCount(count: number) {
+    this._tabHeaderCount = count;
+    this.ref.detectChanges();
+    this.adapterService.detectOverflow();
+  }
+
+  public get tabHeaderCount() {
+    return this._tabHeaderCount;
+  }
 
   @Output()
   public tabClick = new EventEmitter<any>();
 
   @Output()
   public closeClick = new EventEmitter<any>();
+
+  private _allowClose: boolean;
+
+  private _tabHeading: string;
+
+  private _tabHeaderCount: number;
+
+  constructor(
+    private adapterService: SkyTabsetAdapterService,
+    private ref: ChangeDetectorRef
+  ) {}
 
   public doTabClick() {
     if (!this.disabled) {

--- a/src/app/public/modules/tabs/tabset.component.ts
+++ b/src/app/public/modules/tabs/tabset.component.ts
@@ -3,7 +3,6 @@ import {
   AfterViewInit,
   Component,
   ContentChildren,
-  DoCheck,
   ElementRef,
   EventEmitter,
   Input,
@@ -17,9 +16,17 @@ import {
 
 import 'rxjs/add/operator/distinctUntilChanged';
 
-import { SkyTabComponent } from './tab.component';
-import { SkyTabsetAdapterService } from './tabset-adapter.service';
-import { SkyTabsetService } from './tabset.service';
+import {
+  SkyTabComponent
+} from './tab.component';
+
+import {
+  SkyTabsetAdapterService
+} from './tabset-adapter.service';
+
+import {
+  SkyTabsetService
+} from './tabset.service';
 
 @Component({
   selector: 'sky-tabset',
@@ -28,7 +35,7 @@ import { SkyTabsetService } from './tabset.service';
   providers: [SkyTabsetAdapterService, SkyTabsetService]
 })
 export class SkyTabsetComponent
-  implements AfterContentInit, AfterViewInit, DoCheck, OnDestroy, OnChanges {
+  implements AfterContentInit, AfterViewInit, OnDestroy, OnChanges {
 
   @Input()
   public get tabStyle(): string {
@@ -113,6 +120,11 @@ export class SkyTabsetComponent
         change.filter(tab => currentTabs.indexOf(tab) < 0)
               .forEach(item => item.initializeTabIndex());
       });
+
+      // We need the setTimeout here to ensure that the DOM actually has updated for the tab changes
+      setTimeout(() => {
+        this.adapterService.detectOverflow();
+      }, 0);
     });
 
     if (this.active || this.active === 0) {
@@ -145,15 +157,12 @@ export class SkyTabsetComponent
     }, 0);
   }
 
-  public ngDoCheck() {
-    this.adapterService.detectOverflow();
-  }
-
   public ngOnDestroy() {
     this.tabsetService.destroy();
   }
 
   private updateDisplayMode(currentOverflow: boolean) {
     this.tabDisplayMode = currentOverflow ? 'dropdown' : 'tabs';
+    this.changeRef.detectChanges();
   }
 }

--- a/src/app/public/modules/tabs/tabset.service.ts
+++ b/src/app/public/modules/tabs/tabset.service.ts
@@ -1,8 +1,15 @@
-import { Injectable } from '@angular/core';
+import {
+  Injectable
+} from '@angular/core';
 
-import { SkyTabComponent } from './tab.component';
+import {
+  SkyTabComponent
+} from './tab.component';
 
-import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+import {
+  BehaviorSubject
+ } from 'rxjs/BehaviorSubject';
+
 import 'rxjs/add/operator/take';
 
 @Injectable()
@@ -33,7 +40,6 @@ export class SkyTabsetService {
   }
 
   public addTab(tab: SkyTabComponent) {
-
     this.tabs.take(1).subscribe((currentTabs) => {
       if (tab.tabIndex === undefined) {
         tab.tabIndex = 0;
@@ -48,7 +54,6 @@ export class SkyTabsetService {
   }
 
   public destroyTab(tab: SkyTabComponent) {
-
     this.tabs.take(1).subscribe((currentTabs) => {
 
       let tabIndex = currentTabs.indexOf(tab);


### PR DESCRIPTION
Removes `ngDoCheck` in favor of calling the `detectOverflow` method in the appropriate places.

The only place where I believe we have lost the detection is if the tabset component is resized for some reason outside of a window resize. We chatted in standup and felt like that was an ok trade-off for not spamming change detection all the time.

Scenarios that I have manually tested are
1. A tab is added
2. A tab is removed
3. Window resize
4. The tab heading changes and is longer
5. The tab count changes and is longer