### PR TITLE
Release 4.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.6.4 (2021-03-31)
+
+- Replaced theme conditionals in templates with the new `skyThemeIf` directive. [#159](https://github.com/blackbaud/skyux-tabs/pull/159)
+
 # 4.6.3 (2021-03-12)
 
 - Fixed the vertical tab component to ensure all content is rendered prior to responsive styles being added. [#158](https://github.com/blackbaud/skyux-tabs/pull/158)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyux/tabs",
-  "version": "4.6.3",
+  "version": "4.6.4",
   "description": "SKY UX Tabs",
   "scripts": {
     "build": "skyux build-public-library",


### PR DESCRIPTION
- Replaced theme conditionals in templates with the new `skyThemeIf` directive. [#159](https://github.com/blackbaud/skyux-tabs/pull/159)
