### PR TITLE
Updated the vertical tab component to have proper aria attributes

### DIFF
--- a/projects/tabs/src/modules/sectioned-form/sectioned-form-section.component.html
+++ b/projects/tabs/src/modules/sectioned-form/sectioned-form-section.component.html
@@ -1,6 +1,5 @@
 <sky-vertical-tab
   [active]="active"
-  [ariaRequired]="fieldRequired"
   [errorIndicator]="fieldInvalid"
   [ngClass]="{
     'sky-tab-field-required': fieldRequired

--- a/projects/tabs/src/modules/sectioned-form/sectioned-form-section.component.html
+++ b/projects/tabs/src/modules/sectioned-form/sectioned-form-section.component.html
@@ -1,6 +1,5 @@
 <sky-vertical-tab
   [active]="active"
-  [ariaInvalid]="fieldInvalid"
   [ariaRequired]="fieldRequired"
   [errorIndicator]="fieldInvalid"
   [ngClass]="{

--- a/projects/tabs/src/modules/sectioned-form/sectioned-form-section.component.html
+++ b/projects/tabs/src/modules/sectioned-form/sectioned-form-section.component.html
@@ -1,6 +1,5 @@
 <sky-vertical-tab
   [active]="active"
-  [ariaControls]="sectionContentId"
   [ariaInvalid]="fieldInvalid"
   [ariaRequired]="fieldRequired"
   [errorIndicator]="fieldInvalid"
@@ -12,12 +11,5 @@
   [tabHeading]="heading"
   [tabId]="sectionTabId"
 >
-  <div
-    [attr.aria-labelledby]="ariaLabelledby"
-    [attr.role]="ariaRole"
-    [id]="sectionContentId"
-    #tabContent
-  >
-    <ng-content></ng-content>
-  </div>
+  <ng-content></ng-content>
 </sky-vertical-tab>

--- a/projects/tabs/src/modules/sectioned-form/sectioned-form-section.component.ts
+++ b/projects/tabs/src/modules/sectioned-form/sectioned-form-section.component.ts
@@ -49,7 +49,7 @@ export class SkySectionedFormSectionComponent implements OnInit, OnDestroy {
    * @default false
    */
   @Input()
-  public active: boolean;
+  public active: boolean = false;
 
   public fieldRequired: boolean;
   public fieldInvalid: boolean;

--- a/projects/tabs/src/modules/sectioned-form/sectioned-form-section.component.ts
+++ b/projects/tabs/src/modules/sectioned-form/sectioned-form-section.component.ts
@@ -51,21 +51,12 @@ export class SkySectionedFormSectionComponent implements OnInit, OnDestroy {
   @Input()
   public active: boolean;
 
-  public get ariaRole(): string {
-    return this.isMobile ? undefined : 'tabpanel';
-  }
-
-  public get ariaLabelledby() {
-    return this.isMobile ? undefined : this.sectionTabId;
-  }
-
   public fieldRequired: boolean;
   public fieldInvalid: boolean;
 
   @ViewChild(SkyVerticalTabComponent)
   public tab: SkyVerticalTabComponent;
 
-  private isMobile = false;
   private _ngUnsubscribe = new Subject();
 
   constructor(
@@ -75,11 +66,9 @@ export class SkySectionedFormSectionComponent implements OnInit, OnDestroy {
   ) {}
 
   public ngOnInit() {
-    this.isMobile = this.tabsetService.isMobile();
     this.changeRef.detectChanges();
 
     this.tabsetService.switchingMobile.subscribe((mobile: boolean) => {
-      this.isMobile = mobile;
       this.changeRef.detectChanges();
     });
 

--- a/projects/tabs/src/modules/sectioned-form/sectioned-form.component.spec.ts
+++ b/projects/tabs/src/modules/sectioned-form/sectioned-form.component.spec.ts
@@ -147,9 +147,6 @@ describe('Sectioned form component', () => {
 
     let activeTab = tabs[1];
     expect(activeTab.classList.contains('sky-tab-field-required')).toBe(false);
-    expect(
-      activeTab.querySelector('a').getAttribute('aria-required')
-    ).toBeFalsy();
 
     // mark required
     let checkbox = el.querySelector('#requiredTestCheckbox input');
@@ -160,9 +157,6 @@ describe('Sectioned form component', () => {
     tabs = el.querySelectorAll('sky-vertical-tab');
     let requiredTab = tabs[0];
     expect(requiredTab.classList.contains('sky-tab-field-required')).toBe(true);
-    expect(requiredTab.querySelector('a').getAttribute('aria-required')).toBe(
-      'true'
-    );
   });
 
   it('section should respect required field change after switching tabs', () => {
@@ -283,9 +277,6 @@ describe('Sectioned form component', () => {
 
     let firstTab = tabs[0];
     expect(firstTab.querySelector('sky-status-indicator')).toBeNull();
-    expect(
-      firstTab.querySelector('a').getAttribute('aria-invalid')
-    ).toBeFalsy();
 
     // mark invalid
     let checkbox = el.querySelector('#invalidTestCheckbox input');
@@ -294,9 +285,6 @@ describe('Sectioned form component', () => {
 
     // check section is required
     expect(firstTab.querySelector('sky-status-indicator')).not.toBeNull();
-    expect(firstTab.querySelector('a').getAttribute('aria-invalid')).toBe(
-      'true'
-    );
   });
 
   it('section should have appropriate aria labels', () => {
@@ -313,7 +301,7 @@ describe('Sectioned form component', () => {
     let inactiveTabContent = el.querySelector(
       '#' + inactiveTab.getAttribute('aria-controls')
     );
-    expect(inactiveTab.getAttribute('aria-selected')).toBeFalsy();
+    expect(inactiveTab.getAttribute('aria-selected')).toEqual('false');
     expect(inactiveTab.getAttribute('aria-controls')).toBe(
       inactiveTabContent.id
     );

--- a/projects/tabs/src/modules/vertical-tabset/fixtures/vertical-tabset.component.fixture.html
+++ b/projects/tabs/src/modules/vertical-tabset/fixtures/vertical-tabset.component.fixture.html
@@ -11,7 +11,6 @@
     >
       <sky-vertical-tab
         ariaControls="some-div"
-        ariaInvalid="true"
         ariaRole="tab"
         tabHeading="Group 1 Tab 1"
         tabHeaderCount="5"

--- a/projects/tabs/src/modules/vertical-tabset/vertical-tab.component.html
+++ b/projects/tabs/src/modules/vertical-tabset/vertical-tab.component.html
@@ -1,6 +1,6 @@
 <a
   class="sky-vertical-tab"
-  [attr.aria-controls]="ariaControls"
+  [attr.aria-controls]="isMobile ? null : ariaControls || tabContentPane.id"
   [attr.aria-invalid]="ariaInvalid"
   [attr.aria-required]="ariaRequired ? ariaRequired : null"
   [attr.aria-selected]="active"
@@ -46,7 +46,10 @@
     class="sky-vertical-tab-content-pane"
     role="tabpanel"
     tabindex="0"
+    skyId
+    [attr.aria-labelledby]="tabId"
     [ngClass]="{ 'sky-vertical-tab-hidden': !active }"
+    #tabContentPane
   >
     <ng-content></ng-content>
 

--- a/projects/tabs/src/modules/vertical-tabset/vertical-tab.component.html
+++ b/projects/tabs/src/modules/vertical-tabset/vertical-tab.component.html
@@ -1,8 +1,6 @@
 <a
   class="sky-vertical-tab"
   [attr.aria-controls]="isMobile ? null : ariaControls || tabContentPane.id"
-  [attr.aria-invalid]="ariaInvalid"
-  [attr.aria-required]="ariaRequired ? ariaRequired : null"
   [attr.aria-selected]="active"
   [attr.id]="tabId"
   [attr.role]="ariaRole"

--- a/projects/tabs/src/modules/vertical-tabset/vertical-tab.component.ts
+++ b/projects/tabs/src/modules/vertical-tabset/vertical-tab.component.ts
@@ -115,7 +115,7 @@ export class SkyVerticalTabComponent implements OnInit, OnDestroy {
 
   /**
    * Specifies an ID for the tab.
-   * @deprecated Now that the vertical tabs provide aria labels automatically, this input is not longer necessary.
+   * @deprecated Now that the vertical tabs provide aria labels automatically, this input is no longer necessary.
    */
   @Input()
   public tabId: string = `sky-vertical-tab-${++nextId}`;

--- a/projects/tabs/src/modules/vertical-tabset/vertical-tab.component.ts
+++ b/projects/tabs/src/modules/vertical-tabset/vertical-tab.component.ts
@@ -48,7 +48,7 @@ export class SkyVerticalTabComponent implements OnInit, OnDestroy {
    * Specifies the HTML element ID (without the leading `#`) of the element that contains
    * the content that the vertical tab displays, which corresponds to the `tabId`. This property
    * [supports accessibility rules for disclosures](https://www.w3.org/TR/wai-aria-practices-1.1/#disclosure).
-   * @deprecated Now that the vertical tabs provide aria labels automatically, this input is not longer necessary.
+   * @deprecated Now that the vertical tabs provide aria labels automatically, this input is no longer necessary.
    */
   @Input()
   public ariaControls: string;

--- a/projects/tabs/src/modules/vertical-tabset/vertical-tab.component.ts
+++ b/projects/tabs/src/modules/vertical-tabset/vertical-tab.component.ts
@@ -22,6 +22,8 @@ import { SkyVerticalTabsetService } from './vertical-tabset.service';
 
 import { SkyVerticalTabsetAdapterService } from './vertical-tabset-adapter.service';
 
+let nextId = 0;
+
 @Component({
   selector: 'sky-vertical-tab',
   templateUrl: './vertical-tab.component.html',
@@ -46,14 +48,10 @@ export class SkyVerticalTabComponent implements OnInit, OnDestroy {
    * Specifies the HTML element ID (without the leading `#`) of the element that contains
    * the content that the vertical tab displays, which corresponds to the `tabId`. This property
    * [supports accessibility rules for disclosures](https://www.w3.org/TR/wai-aria-practices-1.1/#disclosure).
+   * @deprecated Now that the vertical tabs provide aria labels automatically, this input is not longer necessary.
    */
   @Input()
-  public get ariaControls(): string {
-    return this.isMobile ? undefined : this._ariaControls;
-  }
-  public set ariaControls(value: string) {
-    this._ariaControls = value;
-  }
+  public ariaControls: string;
 
   /**
    * @internal
@@ -74,6 +72,8 @@ export class SkyVerticalTabComponent implements OnInit, OnDestroy {
    * an ARIA role indicates what an item represents on a web page, see the
    * [WAI-ARIA roles model](https://www.w3.org/WAI/PF/aria/roles).
    * @default "tab"
+   * @deprecated Any other value than `tab` could lead to a poor user experience for users with assistive technology.
+   * In the next major version, this property will be automatically set to `tab`.
    */
   @Input()
   public get ariaRole(): string {
@@ -127,9 +127,10 @@ export class SkyVerticalTabComponent implements OnInit, OnDestroy {
 
   /**
    * Specifies an ID for the tab.
+   * @deprecated Now that the vertical tabs provide aria labels automatically, this input is not longer necessary.
    */
   @Input()
-  public tabId: string;
+  public tabId: string = `sky-vertical-tab-${++nextId}`;
 
   public set contentRendered(value: boolean) {
     this._contentRendered = value;
@@ -151,12 +152,10 @@ export class SkyVerticalTabComponent implements OnInit, OnDestroy {
 
   public index: number;
 
+  public isMobile = false;
+
   @ViewChild('tabContentWrapper')
   public tabContent: ElementRef;
-
-  private isMobile = false;
-
-  private _ariaControls: string;
 
   private _ariaRole: string;
 

--- a/projects/tabs/src/modules/vertical-tabset/vertical-tab.component.ts
+++ b/projects/tabs/src/modules/vertical-tabset/vertical-tab.component.ts
@@ -54,18 +54,6 @@ export class SkyVerticalTabComponent implements OnInit, OnDestroy {
   public ariaControls: string;
 
   /**
-   * @internal
-   */
-  @Input()
-  public ariaInvalid: boolean;
-
-  /**
-   * @internal
-   */
-  @Input()
-  public ariaRequired: boolean;
-
-  /**
    * Specifies an ARIA role for the vertical tab
    * [to support accessibility](https://developer.blackbaud.com/skyux/learn/accessibility)
    * by indicating how the tab functions and what it controls. For information about how

--- a/projects/tabs/src/modules/vertical-tabset/vertical-tabset.component.html
+++ b/projects/tabs/src/modules/vertical-tabset/vertical-tabset.component.html
@@ -1,11 +1,14 @@
 <div class="sky-vertical-tabset" (window:resize)="tabService.updateContent()">
   <div
     *ngIf="maintainTabContent || tabService.tabsVisible()"
-    #groupContainerWrapper
+    aria-orientation="vertical"
     class="sky-vertical-tabset-group-container"
     [ngClass]="{ 'sky-vertical-tabset-hidden': !tabService.tabsVisible() }"
+    [attr.aria-label]="ariaLabel"
+    [attr.aria-labelledby]="ariaLabelledBy"
     [attr.role]="ariaRole"
     [@tabGroupEnter]="tabService.animationTabsVisibleState"
+    #groupContainerWrapper
   >
     <ng-content></ng-content>
   </div>

--- a/projects/tabs/src/modules/vertical-tabset/vertical-tabset.component.spec.ts
+++ b/projects/tabs/src/modules/vertical-tabset/vertical-tabset.component.spec.ts
@@ -217,8 +217,6 @@ describe('Vertical tabset component', () => {
     const tab = el.querySelector('sky-vertical-tab a');
     expect(tab.id).toBe('some-tab');
     expect(tab.getAttribute('aria-controls')).toBe('some-div');
-    expect(tab.getAttribute('aria-invalid')).toBe('true');
-    expect(tab.getAttribute('aria-required')).toBe('true');
     expect(tab.getAttribute('role')).toBe('tab');
   });
 

--- a/projects/tabs/src/modules/vertical-tabset/vertical-tabset.component.ts
+++ b/projects/tabs/src/modules/vertical-tabset/vertical-tabset.component.ts
@@ -59,12 +59,31 @@ export class SkyVerticalTabsetComponent
   public showTabsText: string;
 
   /**
+   * Specifies an ARIA label for the tabset. This sets the tabset's `aria-label` attribute
+   * [to support accessibility](https://developer.blackbaud.com/skyux/learn/accessibility).
+   * If the tabset includes a visible label, use `ariaLabelledBy` instead.
+   */
+  @Input()
+  public ariaLabel: string;
+
+  /**
+   * Specifies the HTML element ID (without the leading `#`) of the element that labels
+   * the tabset. This sets the tabset's `aria-labelledby` attribute
+   * [to support accessibility](https://developer.blackbaud.com/skyux/learn/accessibility).
+   * If the tabset does not include a visible label, use `ariaLabel` instead.
+   */
+  @Input()
+  public ariaLabelledBy: string;
+
+  /**
    * Specifies an ARIA role for the vertical tabset
    * [to support accessibility](https://developer.blackbaud.com/skyux/learn/accessibility)
    * by indicating how the tabset functions and what it controls. For information about how
    * an ARIA role indicates what an item represents on a web page, see the
    * [WAI-ARIA roles model](https://www.w3.org/WAI/PF/aria/roles).
    * @default "tablist"
+   * @deprecated Any other value than `tablist` could lead to a poor user experience for users with assistive technology.
+   * In the next major version, this property will be automatically set to `tablist`.
    */
   @Input()
   public get ariaRole(): string {


### PR DESCRIPTION
- Added `ariaLabel` input to the vertical tabset component.
- Added `ariaLabelledBy` input to the vertical tabset component.
- Removed redundant aria logic from the sectioned form now that vertical tabs will just take care of it.